### PR TITLE
Change absolute url to relative

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -377,7 +377,7 @@ Inspired by the [Awesome lists](https://github.com/sindresorhus/awesome).
 
 ## Contributing
 
-Contributions and suggestions are always welcome! Please take a look at the [contribution guidelines](https://github.com/mcauser/awesome-micropython/blob/master/contributing.md) first.
+Contributions and suggestions are always welcome! Please take a look at the [contribution guidelines](contributing.md) first.
 
 ## License & Trademarks
 


### PR DESCRIPTION
Hi @mcauser,
I forked your awesome list in [makersgc/awesome-micropython](https://github.com/makersgc/awesome-micropython), we really like it and we want to contribute to it.

The first change I propose to you is this one in which I change an absolute url to a relative. Specifically I change the contributing guidelines link. In this way it point to the same repository in which one is, without confusing the user.

I hope we can contribute a lot to this awesome list!