### PR TITLE
Micropython EISCP: fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ Other places you can look for MicroPython Libraries:
 
 #### Onkyo EISCP
 
-* [eiscp-micropython](https://github.com/cbrand/eiscp-micropython) - Micropython port for the Onkyo-EISCP protocol used amongs others by Pioneer.
+* [eiscp-micropython](https://github.com/cbrand/eiscp-micropython) - Micropython port for the Onkyo-EISCP protocol used, among others, by Pioneer.
 
 #### Radio
 


### PR DESCRIPTION
On merge I realized some bad typos / spelling in the PR https://github.com/mcauser/awesome-micropython/pull/18.

This PR remedies this and improves the spelling.