### PR TITLE
Removed MicroPython for Everyone book - unlisted at retail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -871,7 +871,6 @@ input via pushbuttons or a navigation joystick and an optional rotary encoder.
 * [MicroPython Projects](https://www.packtpub.com/au/iot-hardware/micropython-projects) - By Jacob Beningo. ISBN 9781789958034.
 * [Get Started with MicroPython on Raspberry Pi Pico](https://store.rpipress.cc/products/get-started-with-micropython-on-raspberry-pi-pico) - By Gareth Halfacree and Ben Everard. ISBN 9781912047864.
 * [MicroPython for Microcontrollers](https://www.elektor.com/micropython-for-microcontrollers-e-book) - By Günter Spanner. ISBN 9783895764370.
-* [MicroPython For Everyone: How To Use ESP32 And ESP8266: Micropython Mqtt](https://www.amazon.com/MicroPython-Everyone-ESP32-ESP8266-Micropython/dp/B094281XK1) - By Mason Milette. ISBN 9798748248822.
 
 ## Frameworks
 


### PR DESCRIPTION
Searched extensively for this book, it shows up in a couple of places, but seems out-of-print / unavailable at retail (and the included Amazon link is 404)

Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>