### PR TITLE
Move PCF8591 from IO expander to ADC section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -499,6 +499,7 @@ input via pushbuttons or a navigation joystick and an optional rotary encoder.
 * [micropython-ads1219](https://github.com/miketeachman/micropython-ads1219) - MicroPython module for the Texas Instruments ADS1219 ADC.
 * [micropython-hx711](https://github.com/SergeyPiskunov/micropython-hx711) - MicroPython driver for HX711 24-Bit Analog-to-Digital Converter.
 * [MicroPython-ADC_Cal](https://github.com/matthias-bs/MicroPython-ADC_Cal) - ESP32 ADC driver using reference voltage calibration value from efuse.
+* [micropython-pcf8591](https://gitlab.com/cediddi/micropython-pcf8591) - MicroPython driver for PCF8591 ADC/DAC, I2C interface.
 
 #### DAC
 
@@ -517,7 +518,6 @@ input via pushbuttons or a navigation joystick and an optional rotary encoder.
 * [micropython-mcp23017](https://github.com/mcauser/micropython-mcp23017) - MicroPython driver for MCP23017 16-bit I/O Expander.
 * [micropython-pcf8574](https://github.com/mcauser/micropython-pcf8574) - MicroPython driver for PCF8574 8-Bit I2C I/O Expander with Interrupt.
 * [micropython-pcf8575](https://github.com/mcauser/micropython-pcf8575) - MicroPython driver for PCF8575 16-Bit I2C I/O Expander with Interrupt.
-* [micropython-pcf8591](https://gitlab.com/cediddi/micropython-pcf8591) - MicroPython driver for PCF8591 8-Bit I2C I/O Expander.
 
 #### Joystick
 


### PR DESCRIPTION
Addresses #58 to clarify that PCF8591 is an ADC/DAC driver.

Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>