### PR TITLE
Add BMP390+BMP180 drivers from octaprog7

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -621,6 +621,8 @@ input via pushbuttons or a navigation joystick and an optional rotary encoder.
 * [micropython_bme280_i2c](https://github.com/triplepoint/micropython_bme280_i2c) - A MicroPython module for communicating with the Bosch BME280 temperature, humidity, and pressure sensor.
 * [MicroPython-BME280](https://github.com/neliogodoi/MicroPython-BME280) - Driver to digital sensor of Temperature, Pressure and Humidity.
 * [micropython-bmp180](https://gitlab.com/flowolf/micropython-bmp180) - A module for MicroPython which provides a class for the BMP180 pressure sensor.
+* [BMP390](https://github.com/octaprog7/BMP390) - MicroPython module for BMP390 pressure & temperature sensor.
+* [BMP180](https://github.com/octaprog7/BMP180) - MicroPython module for BMP180 pressure & temperature sensor.
 
 #### Battery
 


### PR DESCRIPTION
Additional temperature / pressure sensors. Note that the BMP180 has other candidates already in the list, but there were already multiple so I added this one also. BMP390 is new.

Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>