### PR TITLE
Updating broken link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ of required frequency response to a filter implementation.
 
 #### Ethernet
 
-* [Official wiznet5k](https://github.com/micropython/micropython/tree/master/drivers/wiznet5k) - Official driver for the WIZnet5x00 series of Ethernet controllers.
+* [Official wiznet5k](http://docs.micropython.org/en/latest/library/network.WIZNET5K.html?highlight=wiznet5k#class-wiznet5k-control-wiznet5x00-ethernet-modules) - Official driver for the WIZnet5x00 series of Ethernet controllers.
 * [micropy-ENC28J60](https://github.com/przemobe/micropy-ENC28J60) - ENC28J60 Ethernet chip driver for MicroPython (RP2).
 * [RP2040 Ethernet example](https://github.com/SteveSEK/Raspberry-Pi-Pico-MicroPython-Ethernet) - Ethernet driver, example python code and YouTube.
 


### PR DESCRIPTION
Hey @mcauser 

I've noticed a broken link in the list. I've looked for the best possible replacement. I hope this works for you:

http://docs.micropython.org/en/latest/library/network.WIZNET5K.html?highlight=wiznet5k#class-wiznet5k-control-wiznet5x00-ethernet-modules

Cheers,
Peter