### PR TITLE
Suggestions for libraries to add

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,8 +74,8 @@ of required frequency response to a filter implementation.
 * [micropython-jq6500](https://github.com/rdagger/micropython-jq6500) - Driver for JQ6500 UART MP3 modules.
 * [KT403A-MP3](https://github.com/jczic/KT403A-MP3) - Driver for KT403A, used by DFPlayer Mini and Grove MP3 v2.0.
 * [micropython-buzzer](https://github.com/fruch/micropython-buzzer) - Play Nokia compose and mid files on buzzers.
-* [micropython-dfplayer](https://github.com/ShrimpingIt/micropython-dfplayer) - Driver for DFPlayer Mini using UART.
 * [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) - Library to control the DFPlayer mini mp3 player module.
+* [micropython-dfplayer](https://github.com/ShrimpingIt/micropython-dfplayer) - Driver for DFPlayer Mini using UART.
 * [micropython-longwave](https://github.com/MattMatic/micropython-longwave) - WAV player for MicroPython board.
 * [micropython-vs1053](https://github.com/peterhinch/micropython-vs1053) - Asynchronous driver for VS1053b MP3 player.
 * [micropython-midi](https://github.com/cjbarnes18/micropython-midi) - A MIDI implementation example for MicroPython.
@@ -266,6 +266,10 @@ of required frequency response to a filter implementation.
 * [micropython-ppm-decoder](https://github.com/dastultz/micropython-ppm-decoder) - Utility for decoding an R/C receiver PPM frame signal.
 * [ESP32-433Mhz-Receiver-and-Tools](https://github.com/Aschhoff/ESP32-433Mhz-Receiver-and-Tools) - ESP32 433MHz receiver written in MicroPython and tools for Windows.
 
+#### RC receiver
+
+* [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader) - Library to decode PPM signals coming from a RC receiver
+
 #### REPL
 
 * [webrepl](https://micropython.org/webrepl) - MicroPython WebREPL.
@@ -286,10 +290,6 @@ of required frequency response to a filter implementation.
 * [micropython-mcp7940](https://github.com/mattytrentini/micropython-mcp7940) - Driver for the Microchip MCP7940 RTC.
 * [micropython-ds1302-rtc](https://github.com/omarbenhamid/micropython-ds1302-rtc) - DS1302 RTC Clock driver for MicroPython.
 * [DS3231micro](https://github.com/notUnique/DS3231micro) - MicroPython library for DS3231.
-
-#### RC receiver
-
-* [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader) - Library to decode PPM signals coming from a RC receiver
 
 #### Serial
 
@@ -585,8 +585,8 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 
 #### Servo
 
-* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control rc servos using direct PWM output in a tidy way.
 * [micropython-pca9685](https://github.com/mcauser/deshipu-micropython-pca9685) - 16-channel 12-bit PWM/servo driver.
+* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control rc servos using direct PWM output in a tidy way.
 
 #### Stepper
 

--- a/readme.md
+++ b/readme.md
@@ -75,6 +75,7 @@ of required frequency response to a filter implementation.
 * [KT403A-MP3](https://github.com/jczic/KT403A-MP3) - Driver for KT403A, used by DFPlayer Mini and Grove MP3 v2.0.
 * [micropython-buzzer](https://github.com/fruch/micropython-buzzer) - Play Nokia compose and mid files on buzzers.
 * [micropython-dfplayer](https://github.com/ShrimpingIt/micropython-dfplayer) - Driver for DFPlayer Mini using UART.
+* [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) - Library to control the DFPlayer mini mp3 player module.
 * [micropython-longwave](https://github.com/MattMatic/micropython-longwave) - WAV player for MicroPython board.
 * [micropython-vs1053](https://github.com/peterhinch/micropython-vs1053) - Asynchronous driver for VS1053b MP3 player.
 * [micropython-midi](https://github.com/cjbarnes18/micropython-midi) - A MIDI implementation example for MicroPython.
@@ -285,6 +286,10 @@ of required frequency response to a filter implementation.
 * [micropython-mcp7940](https://github.com/mattytrentini/micropython-mcp7940) - Driver for the Microchip MCP7940 RTC.
 * [micropython-ds1302-rtc](https://github.com/omarbenhamid/micropython-ds1302-rtc) - DS1302 RTC Clock driver for MicroPython.
 * [DS3231micro](https://github.com/notUnique/DS3231micro) - MicroPython library for DS3231.
+
+#### RC receiver
+
+* [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader) - Library to decode PPM signals coming from a RC receiver
 
 #### Serial
 
@@ -580,10 +585,12 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 
 #### Servo
 
+* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control rc servos using direct PWM output in a tidy way.
 * [micropython-pca9685](https://github.com/mcauser/deshipu-micropython-pca9685) - 16-channel 12-bit PWM/servo driver.
 
 #### Stepper
 
+* [micropython-stepper](https://github.com/redoxcode/micropython-stepper) - Library to control common stepper drivers in a tidy way.
 * [micropython-upybbot](https://github.com/jeffmer/micropython-upybbot) - A4988 driver for bipolar stepper motors.
 * [uln2003](https://github.com/IDWizard/uln2003) - Driver for 5V 28BYJ-48 stepper motors.
 * [micropython-multiaxis](https://gitlab.com/olivierlenoir/micropython-multiaxis) - Multiaxis with MicroPython ESP32 and DRV8825.

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ of required frequency response to a filter implementation.
 * [micropython-jq6500](https://github.com/rdagger/micropython-jq6500) - Driver for JQ6500 UART MP3 modules.
 * [KT403A-MP3](https://github.com/jczic/KT403A-MP3) - Driver for KT403A, used by DFPlayer Mini and Grove MP3 v2.0.
 * [micropython-buzzer](https://github.com/fruch/micropython-buzzer) - Play Nokia compose and mid files on buzzers.
-* [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) - Library to control the DFPlayer mini mp3 player module.
+* [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) - Library to control the DFPlayer mini MP3 player module.
 * [micropython-dfplayer](https://github.com/ShrimpingIt/micropython-dfplayer) - Driver for DFPlayer Mini using UART.
 * [micropython-longwave](https://github.com/MattMatic/micropython-longwave) - WAV player for MicroPython board.
 * [micropython-vs1053](https://github.com/peterhinch/micropython-vs1053) - Asynchronous driver for VS1053b MP3 player.
@@ -268,7 +268,7 @@ of required frequency response to a filter implementation.
 
 #### RC receiver
 
-* [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader) - Library to decode PPM signals coming from a RC receiver
+* [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader) - Library to decode PPM signals coming from a RC receiver.
 
 #### REPL
 
@@ -586,7 +586,7 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 #### Servo
 
 * [micropython-pca9685](https://github.com/mcauser/deshipu-micropython-pca9685) - 16-channel 12-bit PWM/servo driver.
-* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control rc servos using direct PWM output in a tidy way.
+* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control RC servos using direct PWM output in a tidy way.
 
 #### Stepper
 


### PR DESCRIPTION
Hello everyone,
I want to suggest some of the libraries I created for this list.
These where all created to help using micropython in robotics.
I think they have good documentation and are all downloadable from pypi (so they can used directly from thonny).

- [micropython-ppm_reader](https://github.com/redoxcode/micropython-ppm_reader): No comparable library in the list yet.
- [micropython-servo](https://github.com/redoxcode/micropython-servo): No comparable library in the list yet.
- [micropython-stepper](https://github.com/redoxcode/micropython-stepper): There are some other stepper related libraries in the list. But most lack any documentation :(
- [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer). There is an other library with the exact same name in the list (Yikes!). But I think this one is better documented and more importantly it's the one you get when you search for micropython-dfplayer on pypi. So I think it should be included.

Let me know what you think. Thank you!