### PR TITLE
Add micropython-i2c-lcd lib for HD44780 I2C LCDs with 16x2 and 20x4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -400,6 +400,7 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 * [micropython-lcd](https://github.com/wjdp/micropython-lcd) - Class for controlling the HD44780 from a MicroPython Pyboard.
 * [HD44780-lcd-upy](https://gitlab.com/rafalosa/HD44780-lcd-upy) - MicroPython module for controlling a generic HD44780 LCD.
 * [LCM1602-14_LCD_Library](https://github.com/Bhavithiran97/LCM1602-14_LCD_Library) - driver for AIP31068L [3.3 V I2C and SPI 1602 Serial Character LCDs](https://www.cytron.io/p-3v3-i2c-and-spi-1602-serial-character-lcd).
+* [micropython-i2c-lcd](https://github.com/brainelectronics/micropython-i2c-lcd) - Micropython package to control HD44780 LCD displays 1602 and 2004 via I2C
 
 #### LCD Graphic
 

--- a/readme.md
+++ b/readme.md
@@ -400,7 +400,7 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 * [micropython-lcd](https://github.com/wjdp/micropython-lcd) - Class for controlling the HD44780 from a MicroPython Pyboard.
 * [HD44780-lcd-upy](https://gitlab.com/rafalosa/HD44780-lcd-upy) - MicroPython module for controlling a generic HD44780 LCD.
 * [LCM1602-14_LCD_Library](https://github.com/Bhavithiran97/LCM1602-14_LCD_Library) - driver for AIP31068L [3.3 V I2C and SPI 1602 Serial Character LCDs](https://www.cytron.io/p-3v3-i2c-and-spi-1602-serial-character-lcd).
-* [micropython-i2c-lcd](https://github.com/brainelectronics/micropython-i2c-lcd) - Micropython package to control HD44780 LCD displays 1602 and 2004 via I2C
+* [micropython-i2c-lcd](https://github.com/brainelectronics/micropython-i2c-lcd) - MicroPython package to control HD44780 LCD displays 1602 and 2004 via I2C.
 
 #### LCD Graphic
 


### PR DESCRIPTION
Add `micropython-i2c-lcd` library to README in `LCD Character` section

Available for installation via [PyPI](https://pypi.org/project/micropython-i2c-lcd/), documented at [RTD](https://micropython-i2c-lcd.readthedocs.io/en/latest/) and test released on every PR via [Test PyPI](https://test.pypi.org/project/micropython-i2c-lcd/)
