### PR TITLE
suggesting micropython-servo for addition

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -581,6 +581,7 @@ input via push buttons or a navigation joystick and an optional rotary encoder.
 #### Servo
 
 * [micropython-pca9685](https://github.com/mcauser/deshipu-micropython-pca9685) - 16-channel 12-bit PWM/servo driver.
+* [micropython-servo](https://github.com/redoxcode/micropython-servo) - Library to control RC servos using direct PWM output in a tidy way.
 
 #### Stepper
 


### PR DESCRIPTION
I want to suggest [micropython-servo](https://github.com/redoxcode/micropython-servo) as an addition for this list.
I think the library offers a good documentation and is available for download on pypi and therefore within thonny.
There is no comparable library in the list yet.