### PR TITLE
Suggesting micropython-dfplayer for addition.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ of required frequency response to a filter implementation.
 * [micropython-jq6500](https://github.com/rdagger/micropython-jq6500) - Driver for JQ6500 UART MP3 modules.
 * [KT403A-MP3](https://github.com/jczic/KT403A-MP3) - Driver for KT403A, used by DFPlayer Mini and Grove MP3 v2.0.
 * [micropython-buzzer](https://github.com/fruch/micropython-buzzer) - Play Nokia compose and mid files on buzzers.
+* [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) - Library to control the DFPlayer mini MP3 player module.
 * [micropython-dfplayer](https://github.com/ShrimpingIt/micropython-dfplayer) - Driver for DFPlayer Mini using UART.
 * [micropython-longwave](https://github.com/MattMatic/micropython-longwave) - WAV player for MicroPython board.
 * [micropython-vs1053](https://github.com/peterhinch/micropython-vs1053) - Asynchronous driver for VS1053b MP3 player.


### PR DESCRIPTION
I want to suggest [micropython-dfplayer](https://github.com/redoxcode/micropython-dfplayer) for addition to this list.
There is already a library for the [DFPlayer mini](https://www.dfrobot.com/product-1121.html) with the same name in this list. 
But I think the suggested library offers a better documentation. Also if you search for micropython-dfplayer on pypi or within thonny this is the one that will show up.
I don't want to suggest the existing library to be excluded, but rather this other version to be included as well.
Let me know what you think.