### PR TITLE
suggested addition: FrameBuffer extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,7 @@ of required frequency response to a filter implementation.
 * [micropython-font-to-py](https://github.com/peterhinch/micropython-font-to-py) - A Python 3 utility to convert fonts to Python source capable of being frozen as bytecode.
 * [writer](https://github.com/peterhinch/micropython-font-to-py/blob/master/writer/WRITER.md) - A simple way to render above Python fonts to displays whose driver is subclassed from `framebuf`.
 * [ssd1306big](https://github.com/nickpmulder/ssd1306big) - A font for MicroPython on 128x64 pixel SSD1306 OLED display.
+* [framebuf2](https://github.com/peter-l5/framebuf2) - MicroPython FrameBuffer extension: larger and rotated font, triangles and circles.
 
 #### Graphics
 


### PR DESCRIPTION
Adds framebuf2: a MicroPython FrameBuffer extension: larger and rotated font, triangles and circles