### PR TITLE
Added mcp230xx library with interrupt handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,6 +617,7 @@ Other places you can look for MicroPython Libraries:
 #### IO-Expander
 
 * [micropython-mcp230xx](https://github.com/ShrimpingIt/micropython-mcp230xx) - Driver for MCP23017 and MCP23008 GPIO expanders.
+* [micropython-mcp230xx](https://github.com/dsiggi/micropython-mcp230xx) - Driver for MCP23017 and MCP23008 GPIO expanders, extended with interrupt handling.
 * [micropython-mcp23017](https://github.com/mcauser/micropython-mcp23017) - MicroPython driver for MCP23017 16-bit I/O Expander.
 * [micropython-pcf8574](https://github.com/mcauser/micropython-pcf8574) - MicroPython driver for PCF8574 8-Bit I2C I/O Expander with Interrupt.
 * [micropython-pcf8575](https://github.com/mcauser/micropython-pcf8575) - MicroPython driver for PCF8575 16-Bit I2C I/O Expander with Interrupt.


### PR DESCRIPTION
Added mcp230xx library with interrupt handling.

This is a fork from https://github.com/ShrimpingIt/micropython-mcp230xx which I have extended.