### PR TITLE
Add Micropython Perlin library

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -710,6 +710,7 @@ Other places you can look for MicroPython Libraries:
 * [micropython-fractions](https://github.com/mattytrentini/micropython-fractions) - A MicroPython port of the CPython standard Fractions library.
 * [Sun and Moon](https://github.com/peterhinch/micropython-samples/blob/master/astronomy/README.md) - Determine Sun and Moon rise and set times, Moon phases.
 * [micropython-npyfile](https://github.com/jonnor/micropython-npyfile/) - Numpy .npy file support for MicroPython, supports read/write/streaming.
+* [Micropython Perlin](https://github.com/sjaak31367/micropython_perlin) - A Perlin noise generator module.
 
 ### Motion
 


### PR DESCRIPTION
About a week or two ago I needed a Perlin library for Micropython, but couldn't find any, so I made one!
It's mostly written in C for performance reasons. Though I do plan to still add a vanilla Micropython version, though that will have a notable speed decrease, but will be more compatible / readable.

Greetings!
~Sjaak

P.s. Some sections aren't sorted alphabetically (for example Mathematics), so I've added myself at the bottom of the list.