### PR TITLE
Add Micropython-camera-API to Camera section in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -804,6 +804,7 @@ Other places you can look for MicroPython Libraries:
 
 #### Camera
 
+* [micropython-camera-API](https://github.com/cnadler86/micropython-camera-API) - Project with the aim of supporting cameras across various ports in MicroPython, starting with the ESP32 port and Omnivision cameras (OV2640 & OV5640).
 * [micropython-ov2640](https://github.com/namato/micropython-ov2640) - MicroPython class for OV2640 camera.
 * [Nikon-Trigger-for-MicroPython](https://github.com/Thekegman/Nikon-Trigger-for-MicroPython) - Remote trigger for a Nikon camera using an IR LED. For Pyboard v1.1.
 * [micropython-camera-driver](https://github.com/lemariva/micropython-camera-driver) - OV2640 camera driver for MicroPython on ESP32.


### PR DESCRIPTION
I have just released the first version of my camera-API. I based myself in the API from circuitpython, which is very good IMHO. At the moment I can compile all generic esp32 boards with my driver, and I think, if the repo is more easy to find, more will follow. 