### PR TITLE
Add micropython-zipfile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ Other places you can look for MicroPython Libraries:
 
 * [ufastlz](https://github.com/dmazzella/ufastlz) - MicroPython wrapper for FastLZ, a lightning-fast lossless compression library.
 * [tamp](https://github.com/BrianPugh/tamp) - A low-memory, MicroPython-optimized, DEFLATE-inspired lossless compression library.
+* [micropython-zipfile](https://github.com/jonnor/micropython-zipfile) - Read/write ZIP archive files. Ported from CPython, supports DEFLATE compression.
 
 #### Cryptography
 


### PR DESCRIPTION
I recently needed to read/create some .zip files. So I ported the CPython zipfile module to MicroPython.