### PR TITLE
Add micropidash web dashboard framework

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -441,7 +441,7 @@ Other places you can look for MicroPython Libraries:
 * [CaptiveWebServer](https://github.com/joewez/CaptiveWebServer) - Simple MicroPython web server for serving a website from a captive portal.
 * [micropython-urouter](https://github.com/majoson-chen/micropython-urouter) - A lightweight HTTP request routing processing support library based on MicroPython. The previous name was micro-route.
 * [wlan-relays](https://github.com/oliver-joos/wlan-relays) - Very simple HTTP server written in MicroPython for controlling the pins of an ESP32 board.
-* [micropidash](https://github.com/kritishmohapatra/micropidash) – Lightweight web dashboard for MicroPython (ESP32, Pico W).
+* [micropidash](https://github.com/kritishmohapatra/micropidash) – Simple web dashboard served directly from MicroPython boards (ESP32, Pico W).
 
 #### WiFi
 


### PR DESCRIPTION
Added micropidash, a lightweight web dashboard framework for MicroPython boards like ESP32 and Pico W.
The project is open-source and available on PyPI.
