### PR TITLE
Add MicroPython driver for SHARP memory LCD displays

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -552,6 +552,7 @@ Other places you can look for MicroPython Libraries:
 * [Official LCD160CR](https://github.com/micropython/micropython-lib/tree/master/micropython/drivers/display/lcd160cr) - Driver for official MicroPython LCD160CR display with resistive touch sensor.
 * [micropython-hx1230](https://github.com/mcauser/micropython-hx1230) - MicroPython library for HX1230 96x68 LCD modules.
 * [micropython-SHARP_Memory_Display](https://github.com/pramasoul/micropython-SHARP_Memory_Display) - MicroPython driver for SHARP memory display.
+* [MicroPython-Sharp-Memory-Display](https://github.com/peter-l5/MicroPython-Sharp-Memory-Display) - MicroPython driver for SHARP memory LCD displays.
 
 #### LCD TFT
 


### PR DESCRIPTION
Adds an additional SHARP memory LCD driver. This driver uses a framebuffer and sub-framebuffer to optimise display update speeds.