### PR TITLE
Add openbricks to Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1266,6 +1266,7 @@ Other places you can look for MicroPython Libraries:
 * [perthensis](https://codeberg.org/scy/perthensis) - Perthensis: an asynchronous framework for MicroPython.
 * [meerkat](https://github.com/crdietrich/meerkat) - I2C Data Acquisition for MicroPython and Raspberry Pi.
 * [public-micropython-iot-platform](https://github.com/wolfen351/public-micropython-iot-platform) - Project Fred MicroPython IOT Platform, code to control relays, temp sensors, buttons, touchscreen, GPS etc. Has a responsive Web UI, MQTT, Home Assistant and ThingsBoard support.
+* [openbricks](https://github.com/1e0ng/openbricks) - Pybricks-style robotics firmware for ESP32: 1 kHz native drivebase control, serial bus servos, IMU gyro heading, line sensors, plus a MuJoCo simulator.
 
 ## Resources
 


### PR DESCRIPTION
Adds [openbricks](https://github.com/1e0ng/openbricks) — a Pybricks-style MicroPython robotics firmware for ESP32 (MIT). The robotics library is frozen into a custom firmware build with the motor hot path (drivebase controller, trajectory planner, IMU gyro heading) running at 1 kHz in native C; drives commodity serial-bus servos and sensors, and ships a MuJoCo-based simulator that runs the same API off-hardware. Demo: https://openbricks.dev/#demo